### PR TITLE
fix!: functions should call when pushed onto the stack

### DIFF
--- a/src/heap.zig
+++ b/src/heap.zig
@@ -1,0 +1,264 @@
+const Heap = @This();
+
+used: ?*Header,
+free: ?*Header,
+buf: [*]align(@sizeOf(Header)) u8,
+capacity_in_headers: usize,
+
+pub const Header = struct {
+    size_in_headers: u32,
+    used_size_in_bytes: u32,
+    next: ?*Header,
+
+    fn precedes(a: *Header, b: ?*Header) bool {
+        return @intFromPtr(a) < @intFromPtr(b);
+    }
+
+    fn eql(a: *Header, b: ?*Header) bool {
+        return @intFromPtr(a) == @intFromPtr(b);
+    }
+
+    comptime {
+        std.debug.assert(@alignOf(Header) < @sizeOf(Header));
+    }
+
+    pub fn tag(header: *Header) void {
+        if (isPtrTagged(header.next)) return;
+        header.next = @ptrFromInt(@intFromPtr(header.next) + @alignOf(Header));
+    }
+
+    pub fn isPtrTagged(header: ?*Header) bool {
+        return @intFromPtr(header) % @sizeOf(Header) != 0;
+    }
+
+    pub fn unTagPtr(header: ?*Header) ?*Header {
+        const ptr_int = @intFromPtr(header);
+        return @ptrFromInt(ptr_int - (ptr_int % @sizeOf(Header)));
+    }
+};
+
+pub fn fromAddress(self: Heap, address: u32) ?[*]u8 {
+    if (@as(usize, address) > @sizeOf(Header) * self.capacity_in_headers) return null;
+    return self.buf + address;
+}
+
+pub fn addressOf(self: Heap, ptr: *const anyopaque) error{NotInHeap}!u32 {
+    const location = std.math.sub(usize, @intFromPtr(ptr), @intFromPtr(self.buf)) catch return error.NotInHeap;
+    if (location > @sizeOf(Header) * self.capacity_in_headers) return error.NotInHeap;
+    return std.math.cast(u32, location) orelse return error.NotInHeap;
+}
+
+pub fn containingInUseHeader(self: Heap, address: u32) ?*Header {
+    if (address > @sizeOf(Header) * self.capacity_in_headers) return null;
+    const ptr = @intFromPtr(self.buf) + address;
+    var used = self.used;
+    while (used) |header| : (used = Header.unTagPtr(header.next)) {
+        if (ptr > @intFromPtr(header) and ptr < @intFromPtr(header) + @sizeOf(Header) + header.used_size_in_bytes) return header;
+    }
+    return null;
+}
+
+/// allocates a heap using `backing_allocator` with capacity `capacity` bytes.
+pub fn init(backing_allocator: std.mem.Allocator, capacity: u32) std.mem.Allocator.Error!Heap {
+    const capacity_in_headers = @divFloor(capacity, @sizeOf(Header));
+    const buf = try backing_allocator.alignedAlloc(Header, @sizeOf(Header), capacity_in_headers);
+    buf[0] = .{
+        .size_in_headers = capacity_in_headers,
+        .used_size_in_bytes = 0,
+        .next = null,
+    };
+    return .{
+        .used = null,
+        .free = &buf[0],
+        .buf = @ptrCast(buf.ptr),
+        .capacity_in_headers = capacity_in_headers,
+    };
+}
+
+/// destroys a heap created with `backing_allocator`.
+pub fn deinit(self: *Heap, backing_allocator: std.mem.Allocator) void {
+    const buf: [*]align(@sizeOf(Header)) Header = @ptrCast(self.buf);
+    backing_allocator.free(buf[0..self.capacity_in_headers]);
+    self.* = undefined;
+}
+
+/// returns the type-erased allocator
+pub fn allocator(self: *Heap) std.mem.Allocator {
+    return .{ .ptr = self, .vtable = &.{
+        .alloc = alloc,
+        .resize = resize,
+        .free = free,
+    } };
+}
+
+pub fn discard(self: *Heap, header: *Header) void {
+    var used = self.used;
+    while (used) |ptr| : (used = Header.unTagPtr(ptr.next)) {
+        if (ptr.eql(header)) {
+            const headers_ptr: [*]Header = @ptrCast(header);
+            const buf_ptr: [*]u8 = @ptrCast(headers_ptr + 1);
+            free(self, buf_ptr[0..header.used_size_in_bytes], 0, 0);
+        }
+    }
+}
+
+fn free(ctx: *anyopaque, buf: []u8, _: u8, _: usize) void {
+    const self: *Heap = @ptrCast(@alignCast(ctx));
+    const location_in_bytes = @intFromPtr(buf.ptr) - @intFromPtr(self.buf); // asserts that buf belongs to the heap
+    const idx: usize = @divExact(location_in_bytes, @sizeOf(Header)); // asserts that buf is Header-aligned
+    const buf_len: u32 = @intCast(buf.len); // asserts that buf.len is only a u32
+    const header_ptr: [*]Header = @ptrCast(self.buf);
+    const header = &header_ptr[idx - 1]; // asserts that buf is not the first header
+    std.debug.assert(idx - 1 + header.size_in_headers <= self.capacity_in_headers);
+    if (buf_len != header.used_size_in_bytes) std.debug.panic(
+        "allocated size {d} does not match free size {d}!",
+        .{ header.used_size_in_bytes, buf_len },
+    );
+    header.used_size_in_bytes = 0;
+
+    // remove from the used list
+    blk: {
+        var used = self.used orelse break :blk;
+        if (used.eql(header)) {
+            self.used = Header.unTagPtr(header.next);
+            header.next = null;
+            break :blk;
+        }
+        while (Header.unTagPtr(used.next)) |next| : (used = next) {
+            if (next.eql(header)) {
+                used.next = Header.unTagPtr(header.next);
+                header.next = null;
+                break :blk;
+            }
+        }
+    }
+
+    if (header.precedes(self.free)) {
+        // coalesce chunks: the lhs is the location after the end of the block described by header
+        if (@intFromPtr(header) + (@sizeOf(Header) * header.size_in_headers) == @intFromPtr(self.free)) {
+            header.size_in_headers += self.free.?.size_in_headers;
+            header.next = self.free.?.next;
+        } else header.next = self.free;
+        self.free = header;
+        return;
+    }
+    var prev = self.free orelse {
+        self.free = header;
+        header.next = null;
+        return;
+    };
+    while (prev.precedes(header)) {
+        if (header.precedes(prev.next)) break;
+        const next = prev.next orelse break;
+        std.debug.assert(prev.precedes(next)); // asserts the free list is in order
+        prev = next;
+    }
+
+    // coalesce chunks: the lhs is the location after the end of the block described by header
+    if (@intFromPtr(header) + (@sizeOf(Header) * header.size_in_headers) == @intFromPtr(prev.next)) {
+        header.size_in_headers += prev.next.?.size_in_headers;
+        header.next = prev.next.?.next;
+    } else header.next = prev.next;
+    // coalesce chunks: the lhs is the location after the end of the block described by prev
+    if (@intFromPtr(prev) + (@sizeOf(Header) * @as(usize, prev.size_in_headers)) == @intFromPtr(header)) {
+        prev.size_in_headers += header.size_in_headers;
+        prev.next = header.next;
+    } else prev.next = header;
+}
+
+fn alloc(ctx: *anyopaque, len: usize, ptr_align: u8, _: usize) ?[*]u8 {
+    // we're simply not allocating things that need greater alignment, so this is fine
+    const alignment: std.mem.Allocator.Log2Align = @intCast(ptr_align);
+    if (@as(usize, 1) << alignment > @alignOf(Header)) return null;
+    const self: *Heap = @ptrCast(@alignCast(ctx));
+    const len_in_bytes = std.math.cast(u32, len) orelse return null;
+    // this is the minimum number of header-sized blocks needed to accommodate len bytes and a header;
+    // on overflow, we just return null.
+    const size_in_headers: u32 = std.math.add(u32, @divFloor(
+        std.math.cast(
+            u32,
+            (std.math.add(usize, len, @sizeOf(Header)) catch
+                return null) - 1,
+        ) orelse return null,
+        @sizeOf(Header),
+    ), 1) catch return null;
+
+    // find a chunk that fits
+    const header = header: {
+        var prev = self.free orelse return null;
+        // the first chunk fits
+        if (prev.size_in_headers >= size_in_headers) {
+            // exact fit
+            if (prev.size_in_headers == size_in_headers) {
+                prev.used_size_in_bytes = len_in_bytes;
+                self.free = prev.next;
+                break :header prev;
+            } else {
+                const headers_ptr: [*]Header = @ptrCast(prev);
+                prev.size_in_headers -= size_in_headers;
+                prev = &(headers_ptr + prev.size_in_headers)[0];
+                prev.size_in_headers = size_in_headers;
+                prev.used_size_in_bytes = len_in_bytes;
+                break :header prev;
+            }
+        }
+        while (prev.next) |next| : (prev = next) {
+            if (next.size_in_headers >= size_in_headers) {
+                // exact fit
+                if (next.size_in_headers == size_in_headers) {
+                    next.used_size_in_bytes = len_in_bytes;
+                    prev.next = next.next;
+                    break :header next;
+                } else {
+                    const headers_ptr: [*]Header = @ptrCast(next);
+                    next.size_in_headers -= size_in_headers;
+                    var ret = &(headers_ptr + next.size_in_headers)[0];
+                    ret.size_in_headers = size_in_headers;
+                    ret.used_size_in_bytes = len_in_bytes;
+                    break :header ret;
+                }
+            }
+        }
+        return null;
+    };
+
+    // add to the used list
+    header.next = self.used;
+    self.used = header;
+    const headers_ptr: [*]Header = @ptrCast(header);
+    return @ptrCast(headers_ptr + 1);
+}
+
+fn resize(ctx: *anyopaque, buf: []u8, buf_align: u8, new_len: usize, _: usize) bool {
+    const alignment: std.mem.Allocator.Log2Align = @intCast(buf_align);
+    std.debug.assert(@intFromPtr(buf.ptr) % (@as(usize, 1) << alignment) == 0);
+    if (new_len > buf.len) return false;
+    const self: *Heap = @ptrCast(@alignCast(ctx));
+    const location_in_bytes = @intFromPtr(buf.ptr) - @intFromPtr(self.buf); // asserts that buf belongs to the heap
+    const idx: usize = @divExact(location_in_bytes, @sizeOf(Header)); // asserts that buf is Header-aligned
+    const len: u32 = @intCast(new_len); // asserts that buf.len is only a u32
+    const header_ptr: [*]Header = @ptrCast(self.buf);
+    const header = &header_ptr[idx - 1]; // asserts that buf is not the first header
+    header.used_size_in_bytes = len;
+    return true;
+}
+
+test "basic usage" {
+    var heap = try Heap.init(std.testing.allocator, 0xbeef);
+    try std.testing.expect(heap.used == null);
+    defer heap.deinit(std.testing.allocator);
+    const ally = heap.allocator();
+    {
+        const string = try ally.dupe(u8, "this is a test string!");
+        defer ally.free(string);
+        try std.testing.expect(heap.used != null);
+        const slice = try ally.alloc(usize, 200);
+        @memset(slice, 0xdeadbeef);
+        defer ally.free(slice);
+        const addr = try heap.addressOf(slice.ptr);
+        try std.testing.expect(heap.containingInUseHeader(addr) != null);
+    }
+    try std.testing.expect(heap.used == null);
+}
+
+const std = @import("std");

--- a/src/hither.zig
+++ b/src/hither.zig
@@ -1,369 +1,304 @@
-const wordToFnMap = std.ComptimeStringMap([]const u8, .{
-    .{ "add", "+" },
-    .{ "subtract", "-" },
-    .{ "multiply", "*" },
-    .{ "divide", "/" },
-    .{ "variable", "name" },
-    .{ "call", "call" },
-    .{ "assign", ":=" },
-    .{ "lambdaEnd", "{" },
-    .{ "lambda", "}" },
-    .{ "macro", "$" },
-    .{ "addrOf", "'" },
-    .{ "ifEnd", "if" },
-    .{ "elseEnd", "else" },
-    .{ "then", "then" },
-    .{ "tombstone", "break" },
-    .{ "dupe", "dupe" },
-    .{ "swap", "swap" },
-    .{ "setTo", "top" },
-    .{ "equal", "==" },
-    .{ "whileFn", "while" },
-    .{ "andFn", "and" },
-    .{ "orFn", "or" },
-    .{ "notFn", "not" },
-    .{ "greater", ">" },
-    .{ "greaterEq", ">=" },
-    .{ "less", "<" },
-    .{ "lessEq", "<=" },
-    .{ "whileFn", "while" },
-    .{ "noop", "_" },
-    .{ "after", "," },
-    .{ "dump", "dump" },
-    .{ "print", "print" },
-    .{ "modulo", "%" },
-    .{ "join", "++" },
-    .{ "heightIs", "height" },
-});
-
 const Hither = @This();
 
-stack: Stack,
-pad: *[pad_length]u8,
-pad_idx: usize = 0,
-msg: []const u8 = "",
-lambda_idx: u16 = 0,
-mode: enum { shallow, deep } = .deep,
-writer: ?std.io.AnyWriter = null,
+const Stack = std.MultiArrayList(Cell);
+const Dictionary = std.StringArrayHashMapUnmanaged(Cell);
 
-pub fn nextLambdaName(stack: *Stack, buffer: []u8) []const u8 {
-    const hither: *Hither = @fieldParentPtr("stack", stack);
-    const ret = std.fmt.bufPrint(buffer, "_lmb{x:0>4}", .{hither.lambda_idx}) catch unreachable;
-    hither.lambda_idx += 1;
-    return ret;
-}
-
-test "formatting" {
-    var buf: [16]u8 = undefined;
-    const ret = try std.fmt.bufPrint(&buf, "_lmb{x:0>4}", .{0});
-    try std.testing.expectEqualStrings("_lmb0000", ret);
-    const ret2 = try std.fmt.bufPrint(&buf, "_lmb{x:0>4}", .{0xdead});
-    try std.testing.expectEqualStrings("_lmbdead", ret2);
-}
-
-pub fn init(buffer: []align(@alignOf(Cell)) u8) error{StackTooSmall}!Hither {
-    var self: Hither = .{ .stack = Stack.init(buffer), .pad = undefined };
-
-    const lib = @import("standard_library.zig");
-    const info = @typeInfo(lib);
-    inline for (info.Struct.decls) |decl| {
-        const name = wordToFnMap.get(decl.name).?;
-        const Fn = @field(lib, decl.name);
-        const prev = self.stack.here;
-        addAtHere(&self.stack, .{ .machine = Fn }) catch return error.StackTooSmall;
-        addAtHere(&self.stack, .{ .addr = .{ .address = @intCast(prev -| 1) } }) catch return error.StackTooSmall;
-        try addUtf8ToDictionary(&self.stack, name);
-    }
-    self.pad = &self.stack.bytes[self.stack.here * 8 + pad ..][0..pad_length].*;
-    return self;
-}
-
-pub fn setMsgFmt(self: *Hither, comptime fmt: []const u8, args: anytype) []const u8 {
-    const slice = self.pad[self.pad_idx..];
-    var stream = std.io.fixedBufferStream(slice);
-    var writer = stream.writer();
-    writer.print(fmt, args) catch return "error while setting msg!";
-    return slice[0..stream.pos];
-}
-
-pub fn parse(self: *Hither, stream: anytype) Result {
-    const input = stream.readUntilDelimiterOrEof(self.pad[self.pad_idx..], '\n') catch |err| {
-        if (err == error.EndOfStream) return .quit;
-        self.msg = setMsgFmt(self, "read error: {s}", .{@errorName(err)});
-        return .err;
-    } orelse return .quit;
-    defer self.pad_idx += input.len;
-    if (std.mem.startsWith(u8, input, "quit")) return .quit;
-    var iterator = std.mem.tokenizeAny(u8, input, " \t\n\r()[]");
-    while (iterator.next()) |token| {
-        const cell = cellFromToken(self, token, iterator.index - token.len) catch |err| {
-            self.msg = setMsgFmt(self, "parse error: {s}", .{@errorName(err)});
-            return .err;
-        };
-        push(&self.stack, cell) catch {
-            self.msg = "stack overflow!";
-            return .err;
-        };
-    }
-    return .ok;
-}
-
-fn cellFromToken(self: *Hither, token: []const u8, idx: usize) !Cell {
-    int: {
-        const ret: Cell = .{ .integer = std.fmt.parseInt(i64, token, 0) catch break :int };
-        return ret;
-    }
-    float: {
-        const ret: Cell = .{ .number = std.fmt.parseFloat(f64, token) catch break :float };
-        return ret;
-    }
-    if (token[0] == '\"' and token[token.len - 1] == '\"') {
-        const ret: Cell = .{
-            .slice = .{ .address = @intCast(self.pad_idx + idx), .length = @intCast(token.len) },
-        };
-        return ret;
-    }
-    return try lookUpWord(&self.stack, token);
-}
-
-pub fn sliceFromSlice(self: *Hither, cell: Cell) Error![]const u8 {
-    if (cell != .slice) return error.BadArguments;
-    return self.pad[cell.slice.address..][0..cell.slice.length];
-}
-
-pub fn lookUpWord(stack: *Stack, token: []const u8) !Cell {
-    const len = try std.math.divCeil(usize, token.len, 8);
-    if (len > 255) return error.WordTooLong;
-    var iterator = iterateDictionary(stack);
-    while (iterator.next()) |entry| {
-        if (len != entry.name_len) continue;
-        if (!entry.match(stack, token)) continue;
-        // std.debug.print("{}\n", .{stack.get(entry.address - (entry.name_len + 1))});
-        return .{ .addr = .{ .address = entry.address - (entry.name_len + 1) } };
-    }
-    return error.NotFound;
-}
-
-const DictionaryIterator = struct {
-    stack: *const Stack,
-    current: ?Entry,
-
-    fn next(self: *DictionaryIterator) ?Entry {
-        const curr = self.current orelse return null;
-        const ptr = curr.address - curr.name_len;
-        const data = self.stack.get(ptr);
-        if (data.addr.address == 0) {
-            self.current = null;
-            return curr;
-        }
-        // std.debug.print("next addr: 0x{x}\n", .{data.addr.address});
-        const new_ptr = self.stack.get(data.addr.address);
-        self.current = .{
-            .name_len = new_ptr.len.length,
-            .address = data.addr.address -| 1,
-        };
-        return curr;
-    }
-
-    const Entry = struct {
-        name_len: u8,
-        address: u32,
-
-        fn match(self: Entry, stack: *const Stack, word: []const u8) bool {
-            var idx: usize = 0;
-            var name_ptr = self.address;
-            while (idx < word.len) : (idx += 8) {
-                const data = stack.get(name_ptr);
-                const haystack: *const [8]u8 = @ptrCast(&data.utf8);
-                const needle = word[idx..][0..@min(8, word[idx..].len)];
-                const slice: []const u8 = if (std.mem.indexOfScalar(u8, haystack, 0)) |n| haystack[0..n] else haystack;
-                if (!std.mem.eql(u8, slice, needle)) return false;
-                name_ptr -= 1;
-            }
-            return true;
-        }
-    };
+pub const Error = error{
+    OutOfMemory,
+    StackOverflow,
+    BadArgument,
+    ArithmeticOverflow,
+    ZeroDenominator,
+    PairMismatch,
+    NotSupported,
+    IOError,
+    WordNotFound,
 };
 
-fn iterateDictionary(stack: *const Stack) DictionaryIterator {
-    return .{ .stack = stack, .current = .{
-        .name_len = stack.get(stack.here - 1).len.length,
-        .address = @intCast(stack.here - 2),
-    } };
+heap: Heap,
+stack: Stack,
+ret: Stack,
+quotation_level: u1 = 0,
+dictionary: Dictionary,
+msg: []const u8 = "",
+output: ?std.io.AnyWriter = null,
+
+pub const Cell = struct {
+    pub const Tag = enum(u2) {
+        slice,
+        integer,
+        number,
+        builtin,
+    };
+
+    tag: Tag,
+    slice_is: enum(u2) {
+        string,
+        word,
+        definition,
+    } = .string,
+    data: packed union {
+        slice: packed struct {
+            address: u32,
+            length: u32,
+        },
+        integer: i64,
+        number: f64,
+        builtin: *const fn (*Hither) Error!void,
+    },
+
+    pub fn eqlShallow(a: Cell, b: Cell) bool {
+        if (a.tag != b.tag) return false;
+        return switch (a.tag) {
+            .slice => a.data.slice.address == b.data.slice.address and a.data.slice.length == b.data.slice.length,
+            .integer => a.data.integer == b.data.integer,
+            .number => a.data.number == b.data.number,
+            .builtin => @intFromPtr(a.data.builtin) == @intFromPtr(b.data.builtin),
+        };
+    }
+
+    pub fn format(cell: Cell, comptime _: []const u8, _: std.fmt.FormatOptions, writer: anytype) !void {
+        switch (cell.tag) {
+            .slice => try writer.print("slice: address: 0x{x}, length: {d}, type: {s}", .{ cell.data.slice.address, cell.data.slice.length, @tagName(cell.slice_is) }),
+            .integer => try writer.print("{d}", .{cell.data.integer}),
+            .number => try writer.print("{d}", .{cell.data.number}),
+            .builtin => try writer.print("function, address: 0x{x}", .{@intFromPtr(cell.data.builtin)}),
+        }
+    }
+
+    test Cell {
+        const a: Cell = .{
+            .tag = .slice,
+            .data = .{ .slice = .{ .address = 0xdeadbeef, .length = 0xfeedbacc } },
+        };
+        const b: Cell = .{
+            .tag = .slice,
+            .data = .{ .slice = .{ .address = 0xdeadbeef, .length = 0xfeedbacc } },
+        };
+        const c: Cell = .{
+            .tag = .integer,
+            .data = .{ .integer = @bitCast(@as(u64, 0xfeedbaccdeadbeef)) },
+        };
+        try std.testing.expectEqual(@as(i64, @bitCast(a.data.slice)), c.data.integer);
+        try std.testing.expect(a.eqlShallow(b));
+        try std.testing.expect(!a.eqlShallow(c));
+    }
+};
+
+pub fn init(allocator: std.mem.Allocator, stack_size: usize, dictionary_size: usize, heap_size: u32) std.mem.Allocator.Error!Hither {
+    var hither: Hither = .{
+        .heap = try Heap.init(allocator, heap_size),
+        .stack = .{},
+        .ret = .{},
+        .dictionary = try Dictionary.init(allocator, hither_lib.keys, hither_lib.vals),
+    };
+    try hither.stack.ensureUnusedCapacity(allocator, stack_size);
+    try hither.ret.ensureUnusedCapacity(allocator, stack_size);
+    try hither.dictionary.ensureUnusedCapacity(allocator, dictionary_size);
+    return hither;
 }
 
-pub const Result = enum { err, ok, quit, incomplete };
+pub fn deinit(hither: *Hither, allocator: std.mem.Allocator) void {
+    hither.stack.deinit(allocator);
+    hither.ret.deinit(allocator);
+    hither.dictionary.deinit(allocator);
+    hither.heap.deinit(allocator);
+    hither.* = undefined;
+}
 
-pub fn tick(self: *Hither) Result {
-    const cell = (pop(&self.stack) catch |err| {
-        switch (err) {
-            error.BadArguments => self.msg = "bad arguments!",
-            error.DivisionByZero => self.msg = "division by zero!",
-            error.MathOverflow => self.msg = "math operation overflow!",
-            error.StackOverflow => self.msg = "stack overflow!",
-            error.NotSupported => self.msg = "operation not supported!",
-            error.IOError => self.msg = "i/o error!",
+pub fn printStack(hither: *Hither, writer: std.io.AnyWriter) !void {
+    while (hither.stack.popOrNull()) |cell| {
+        switch (cell.tag) {
+            .slice => {
+                if (cell.slice_is != .definition) {
+                    const bytes = hither.heap.fromAddress(cell.data.slice.address).?;
+                    try writer.writeAll(bytes[0..cell.data.slice.length]);
+                    try writer.writeAll("\n");
+                } else try writer.print("{}\n", .{cell});
+            },
+            else => try writer.print("{}\n", .{cell}),
         }
+    }
+}
+
+pub fn dumpState(hither: *Hither, writer: std.io.AnyWriter) !void {
+    try writer.writeAll("---------------\n");
+    try writer.writeAll("RETURN STACK:\n");
+    for (0..hither.ret.len) |i| {
+        try writer.print("{any}\n", .{hither.ret.get(hither.ret.len - 1 - i)});
+    }
+    try writer.writeAll("STACK:\n");
+    for (0..hither.stack.len) |i| {
+        try writer.print("{any}\n", .{hither.stack.get(hither.stack.len - 1 - i)});
+    }
+    try writer.writeAll("---------------\n");
+}
+
+pub const Result = enum { ok, err, incomplete, quit };
+
+pub fn parse(hither: *Hither, input: std.io.AnyReader, output: std.io.AnyWriter) Result {
+    hither.output = output;
+    const allocator = hither.heap.allocator();
+    const line = input.readUntilDelimiterOrEofAlloc(allocator, '\n', 2048) catch |err| {
+        if (err == error.StreamTooLong) hither.msg = "input line too long! max size is 2048 bytes";
+        hither.msg = std.fmt.allocPrint(allocator, "read error: {s}", .{@errorName(err)}) catch "out of memory while printing error message!";
         return .err;
-    }) orelse return .ok;
-    switch (cell) {
-        .len => {
-            self.msg = "bad stack state!";
+    } orelse return .quit;
+    if (std.mem.eql(u8, line, "quit")) return .quit;
+    var iterator = std.mem.tokenizeAny(u8, line, "\r\n\t ");
+    while (iterator.next()) |token| {
+        const cell: Cell = cell: {
+            int: {
+                const int = std.fmt.parseInt(i64, token, 0) catch break :int;
+                break :cell .{ .tag = .integer, .data = .{ .integer = int } };
+            }
+            number: {
+                const number = std.fmt.parseFloat(f64, token) catch break :number;
+                break :cell .{ .tag = .number, .data = .{ .number = number } };
+            }
+            slice: {
+                if (token[0] != '\"') break :slice;
+                const addr = hither.heap.addressOf(token.ptr + 1) catch unreachable;
+                if (token.len > 1 and token[token.len - 1] == '\"') {
+                    break :cell .{
+                        .tag = .slice,
+                        .data = .{
+                            .slice = .{ .address = addr, .length = @intCast(token.len - 2) },
+                        },
+                    };
+                }
+                const start = (iterator.index + 1) - token.len;
+                while (iterator.next()) |next| {
+                    if (next[next.len - 1] == '\"') {
+                        break :cell .{
+                            .tag = .slice,
+                            .data = .{
+                                .slice = .{ .address = addr, .length = @intCast(iterator.index - (start + 1)) },
+                            },
+                        };
+                    }
+                }
+                hither.msg = "parse error: unterminated string!";
+                return .err;
+            }
+            const addr = hither.heap.addressOf(token.ptr) catch unreachable;
+            break :cell .{
+                .tag = .slice,
+                .slice_is = .word,
+                .data = .{
+                    .slice = .{ .address = addr, .length = @intCast(token.len) },
+                },
+            };
+        };
+        hither.push(cell) catch |err| {
+            hither.msg = switch (err) {
+                error.OutOfMemory => "error: out of memory!",
+                error.ArithmeticOverflow => "error: arithmetic overflow!",
+                error.BadArgument => "error: bad argument!",
+                error.StackOverflow => "error: stack overflow!",
+                error.ZeroDenominator => "error: zero in denominator!",
+                error.PairMismatch => "error: closing word found without matching opening word!",
+                error.NotSupported => "error: that operation is not supported!",
+                error.IOError => "error while performing I/O!",
+                error.WordNotFound => "error: no definition found for word!",
+            };
             return .err;
+        };
+    }
+    return if (hither.ret.len != 0) .incomplete else .ok;
+}
+
+pub fn flush(hither: *Hither) void {
+    hither.msg = "";
+    hither.stack.len = 0;
+    hither.ret.len = 0;
+    hither.markAndSweep();
+}
+
+pub fn push(hither: *Hither, cell: Cell) Error!void {
+    switch (cell.tag) {
+        .builtin => {
+            if (hither.ret.len == hither.ret.capacity) return error.StackOverflow;
+            hither.ret.appendAssumeCapacity(cell);
+            try @call(.auto, cell.data.builtin, .{hither});
+        },
+        .slice => {
+            switch (cell.slice_is) {
+                .string => {
+                    if (hither.stack.len == hither.stack.capacity) return error.StackOverflow;
+                    hither.stack.appendAssumeCapacity(cell);
+                },
+                .definition => {
+                    if (hither.ret.len == hither.ret.capacity) return error.StackOverflow;
+                    hither.ret.appendAssumeCapacity(cell);
+                    try hither_lib.iterateThrough(hither);
+                },
+                .word => {
+                    if (hither.ret.len == hither.ret.capacity) return error.StackOverflow;
+                    hither.ret.appendAssumeCapacity(cell);
+                    try hither_lib.lookUpWord(hither);
+                },
+            }
         },
         else => {
-            if (self.stack.stack_ptr != self.stack.capacity) {
-                push(&self.stack, cell) catch unreachable;
-                return .incomplete;
-            }
-            self.msg = self.setMessage(cell) catch "unable to print!";
-            return .ok;
+            if (hither.stack.len == hither.stack.capacity) return error.StackOverflow;
+            hither.stack.appendAssumeCapacity(cell);
         },
     }
 }
 
-fn setMessage(self: *Hither, cell: Cell) ![]const u8 {
-    const slice = self.pad[self.pad_idx..];
-    var stream = std.io.fixedBufferStream(slice);
-    var writer = stream.writer();
-    switch (cell) {
-        .slice => return sliceFromSlice(self, cell) catch unreachable,
-        else => try writer.print("{}", .{cell}),
+pub fn popReturn(hither: *Hither) ?Cell {
+    return hither.ret.popOrNull();
+}
+
+pub fn pop(hither: *Hither) ?Cell {
+    return hither.stack.popOrNull();
+}
+
+fn tagContainingHeader(hither: *Hither, cell: Cell) void {
+    switch (cell.tag) {
+        .slice => {
+            const header = hither.heap.containingInUseHeader(cell.data.slice.address) orelse return;
+            // attempt to short-circuit recursive tagging
+            if (Heap.Header.isPtrTagged(header.next)) return;
+            header.tag();
+            if (cell.slice_is != .definition) return;
+            const ptr = hither.heap.fromAddress(cell.data.slice.address) orelse return;
+            const cells: [*]Cell = @ptrCast(@alignCast(ptr));
+            for (cells[0..cell.data.slice.length]) |c| hither.tagContainingHeader(c);
+        },
+        else => {},
     }
-    self.pad_idx += stream.pos;
-    return slice[0..stream.pos];
 }
 
-pub fn flush(self: *Hither) void {
-    self.stack.stack_ptr = self.stack.capacity;
-    self.msg = "";
-    const old_pad = self.pad;
-    self.pad = &self.stack.bytes[self.stack.here * 8 + pad ..][0..pad_length].*;
-    std.mem.copyBackwards(u8, self.pad, old_pad);
-}
-
-pub fn addUtf8ToDictionary(stack: *Stack, utf8name: []const u8) error{StackTooSmall}!void {
-    const block_len: u8 = @intCast(std.math.divCeil(usize, utf8name.len, 8) catch unreachable);
-    const rem: u3 = @intCast(utf8name.len % 8);
-    const len: Cell = .{ .len = .{ .length = block_len } };
-    var idx = utf8name.len;
-    if (rem > 0) {
-        var utf8: [8]u8 = .{0} ** 8;
-        @memcpy(utf8[0..rem], utf8name[utf8name.len - rem ..]);
-        const last: Cell = .{ .utf8 = @bitCast(utf8) };
-        addAtHere(stack, last) catch return error.StackTooSmall;
-        idx -= rem;
+fn markAndSweep(hither: *Hither) void {
+    // mark
+    for (hither.dictionary.keys()) |key| {
+        const addr = hither.heap.addressOf(key.ptr) catch continue;
+        const header = hither.heap.containingInUseHeader(addr) orelse continue;
+        header.tag();
     }
-    while (idx >= 8) {
-        idx -= 8;
-        const utf8: Cell = .{ .utf8 = @bitCast(utf8name[idx..][0..8].*) };
-        addAtHere(stack, utf8) catch return error.StackTooSmall;
+    for (hither.dictionary.values()) |cell| hither.tagContainingHeader(cell);
+    // sweep
+    var used = hither.heap.used;
+    while (used) |ptr| {
+        used = Heap.Header.unTagPtr(ptr.next);
+        if (Heap.Header.isPtrTagged(ptr.next)) continue;
+        hither.heap.discard(ptr);
     }
-    addAtHere(stack, len) catch return error.StackTooSmall;
-}
-
-pub fn addAtHere(stack: *Stack, cell: Cell) error{StackOverflow}!void {
-    try roomAbove(stack, 1);
-    stack.set(stack.here, cell);
-    stack.here += 1;
-}
-
-// resolves according to stack.mode
-pub fn pop(stack: *Stack) Error!?Cell {
-    const hither: *Hither = @fieldParentPtr("stack", stack);
-    defer hither.mode = .deep;
-    if (stack.stack_ptr == stack.capacity) return null;
-    var res = stack.get(stack.stack_ptr);
-    // std.log.debug("popped {} in mode {s}", .{ res, @tagName(hither.mode) });
-    stack.stack_ptr += 1;
-    while (hither.mode == .deep) {
-        switch (res) {
-            .machine => |m| {
-                try m(stack);
-                if (stack.stack_ptr == stack.capacity) return null;
-                res = stack.get(stack.stack_ptr);
-                stack.stack_ptr += 1;
-            },
-            .addr => |a| {
-                var addr = a.address;
-                while (addr > 0) : (addr -= 1) {
-                    const cell = stack.get(addr);
-                    if (cell == .len) break;
-                    try push(stack, cell);
-                }
-                if (stack.stack_ptr == stack.capacity) return null;
-                res = stack.get(stack.stack_ptr);
-                stack.stack_ptr += 1;
-            },
-            else => break,
-        }
+    used = hither.heap.used;
+    while (used) |ptr| : (used = ptr.next) {
+        ptr.next = Heap.Header.unTagPtr(ptr.next);
     }
-    return res;
 }
 
-/// idx is an index into the stack portion of the stack.
-/// positive indices count down from the top, with `0` being the top of the stack
-/// negative indices count up from the bottom, with `-1` being the bottom
-pub fn idxToOffset(stack: *const Stack, idx: i64) ?usize {
-    const sign = idx >= 0;
-    const offset: u32 = @abs(idx);
-    const res = if (sign) stack.stack_ptr +| offset else stack.capacity -| offset;
-    if (!(res >= stack.stack_ptr and res <= stack.capacity)) return null;
-    return res;
+test "ref" {
+    _ = Hither;
+    _ = Cell;
+    _ = Heap;
+    _ = hither_lib;
 }
-
-pub fn typeAt(stack: *const Stack, idx: i64) ?Stack.Elem.Tag {
-    const offset = idxToOffset(stack, idx) orelse return null;
-    const slice = stack.slice();
-    const types = slice.items(.tag);
-    return types[offset];
-}
-
-pub fn push(stack: *Stack, cell: Cell) error{StackOverflow}!void {
-    try roomAbove(stack, 1);
-    stack.stack_ptr -= 1;
-    stack.set(stack.stack_ptr, cell);
-    // std.log.debug("pushed {}", .{cell});
-}
-
-pub fn roomAbove(stack: *const Stack, num_elems: usize) error{StackOverflow}!void {
-    if (stack.here + pad_length + pad + num_elems >= stack.stack_ptr) return error.StackOverflow;
-}
-
-pub fn checkDepth(stack: *const Stack, num_elems: usize) bool {
-    return stack.stack_ptr + num_elems <= stack.capacity;
-}
-
-pub fn toNumber(cell: Cell) error{BadArguments}!f64 {
-    if (!isArithmetic(cell)) return error.BadArguments;
-    return switch (cell) {
-        .integer => |i| @floatFromInt(i),
-        .number => |f| f,
-        else => unreachable,
-    };
-}
-
-pub fn isArithmetic(t: Stack.Elem.Tag) bool {
-    return switch (t) {
-        .integer, .number => true,
-        else => false,
-    };
-}
-
-pub fn mathCoerce(t1: Stack.Elem.Tag, t2: Stack.Elem.Tag) error{BadArguments}!Stack.Elem.Tag {
-    if (!(isArithmetic(t1) and isArithmetic(t2))) return error.BadArguments;
-    return switch (t1) {
-        .integer => if (t2 == .integer) .integer else .number,
-        .number => .number,
-        else => unreachable,
-    };
-}
-
-const pad_length = 128 * 1024 * 8;
-const pad = 1024 * 8;
 
 const std = @import("std");
-const s = @import("stack.zig");
-const Stack = s.Stack;
-pub const Cell = s.Cell;
-const Error = s.Error;
+const Heap = @import("heap.zig");
+const hither_lib = @import("hither_lib.zig");

--- a/src/hither_lib.zig
+++ b/src/hither_lib.zig
@@ -1,0 +1,765 @@
+pub const keys = constructKeysVals(.keys);
+pub const vals = constructKeysVals(.vals);
+
+fn constructKeysVals(comptime which: enum { keys, vals }) switch (which) {
+    .keys => []const []const u8,
+    .vals => []const Cell,
+} {
+    const map = [_][2][]const u8{
+        .{ "+", "add" },
+        .{ "-", "subtract" },
+        .{ "*", "multiply" },
+        .{ "/", "divide" },
+        .{ "%", "modulo" },
+        .{ ">", "greater" },
+        .{ ">=", "greaterEq" },
+        .{ "<", "less" },
+        .{ "<=", "lessEq" },
+        .{ "==", "equal" },
+        .{ "dupe", "dupe" },
+        .{ "swap", "swap" },
+        .{ "height", "heightIs" },
+        .{ "top", "setTo" },
+        .{ "drop", "drop" },
+        .{ "and", "andFn" },
+        .{ "or", "orFn" },
+        .{ "not", "notFn" },
+        .{ "print", "print" },
+        .{ "++", "join" },
+        .{ ":=", "variable" },
+        .{ "@", "call" },
+        .{ "while", "whileFn" },
+        .{ "_", "noop" },
+        .{ "'", "xt" },
+        .{ "{", "lambdaStart" },
+        .{ "}", "lambdaEnd" },
+        .{ "if", "ifStart" },
+        .{ "else", "elseStart" },
+        .{ "then", "then" },
+        .{ "exit", "exit" },
+        .{ "dump", "dumpState" },
+        .{ "inspect", "inspect" },
+        .{ "abort", "breakFn" },
+    };
+    return switch (which) {
+        .keys => comptime blk: {
+            var ret: [map.len][]const u8 = undefined;
+            for (map, 0..) |pair, i| {
+                ret[i] = pair[0];
+            }
+            const keys_list = ret;
+            break :blk &keys_list;
+        },
+        .vals => comptime blk: {
+            var ret: [map.len]Cell = undefined;
+            for (map, 0..) |pair, i| {
+                ret[i] = .{
+                    .tag = .builtin,
+                    .data = .{ .builtin = @field(@This(), pair[1]) },
+                };
+            }
+            const vals_list = ret;
+            break :blk &vals_list;
+        },
+    };
+}
+
+/// most functions in this file should begin with the line `if (try preamble(hither)) return;`
+fn preamble(hither: *Hither) Error!bool {
+    // pops the function which was just pushed onto the return stack
+    const this = hither.ret.pop();
+    if (isXt(hither) or isDeferred(hither)) {
+        if (hither.stack.len == hither.stack.capacity) return error.StackOverflow;
+        hither.stack.appendAssumeCapacity(this);
+        return true;
+    }
+    return false;
+}
+
+/// returns true if the value on top of the stack is a deferred-execution builtin
+/// e.g. (`if`, `else`, the opening of a `{` `}` pair, and so on)
+fn isDeferred(hither: *Hither) bool {
+    const this = hither.ret.popOrNull() orelse return false;
+    defer hither.ret.appendAssumeCapacity(this);
+    const deferred_builtins = [_][]const u8{
+        "lambdaStart",
+        "ifStart",
+        "elseStart",
+    };
+    inline for (deferred_builtins) |name| {
+        const cell: Cell = .{
+            .tag = .builtin,
+            .data = .{ .builtin = @field(@This(), name) },
+        };
+        if (this.eqlShallow(cell)) return true;
+    }
+    return false;
+}
+
+/// returns true if the value on top of the return stack is xt, and pops it if so
+fn isXt(hither: *Hither) bool {
+    const this = hither.ret.popOrNull() orelse return false;
+    const xt_cell: Cell = .{
+        .tag = .builtin,
+        .data = .{ .builtin = xt },
+    };
+    if (this.eqlShallow(xt_cell)) return true;
+    // it wasn't xt; put it back
+    hither.ret.appendAssumeCapacity(this);
+    return false;
+}
+
+fn arithmeticCoerce(a: Cell.Tag, b: Cell.Tag) error{BadArgument}!Cell.Tag {
+    return switch (a) {
+        .integer => switch (b) {
+            .integer => .integer,
+            .number => .number,
+            else => error.BadArgument,
+        },
+        .number => switch (b) {
+            .integer, .number => .number,
+            else => error.BadArgument,
+        },
+        else => error.BadArgument,
+    };
+}
+
+fn toNumber(cell: Cell) error{BadArgument}!f64 {
+    return switch (cell.tag) {
+        .integer => @floatFromInt(cell.data.integer),
+        .number => cell.data.number,
+        else => error.BadArgument,
+    };
+}
+
+// -- ARITHMETIC --
+
+fn add(hither: *Hither) Error!void {
+    if (try preamble(hither)) return;
+    const a = hither.pop() orelse return error.BadArgument;
+    const b = hither.pop() orelse return error.BadArgument;
+    const ret_type = try arithmeticCoerce(a.tag, b.tag);
+    switch (ret_type) {
+        .integer => try hither.push(.{
+            .tag = .integer,
+            .data = .{
+                .integer = std.math.add(i64, a.data.integer, b.data.integer) catch return error.ArithmeticOverflow,
+            },
+        }),
+
+        .number => {
+            const float_a = toNumber(a) catch unreachable;
+            const float_b = toNumber(b) catch unreachable;
+            try hither.push(.{ .tag = .number, .data = .{ .number = float_a + float_b } });
+        },
+        else => unreachable,
+    }
+}
+
+fn subtract(hither: *Hither) Error!void {
+    if (try preamble(hither)) return;
+    const a = hither.pop() orelse return error.BadArgument;
+    const b = hither.pop() orelse return error.BadArgument;
+    const ret_type = try arithmeticCoerce(a.tag, b.tag);
+    switch (ret_type) {
+        .integer => try hither.push(.{
+            .tag = .integer,
+            .data = .{
+                .integer = std.math.sub(i64, b.data.integer, a.data.integer) catch return error.ArithmeticOverflow,
+            },
+        }),
+        .number => {
+            const float_a = toNumber(a) catch unreachable;
+            const float_b = toNumber(b) catch unreachable;
+            try hither.push(.{ .tag = .number, .data = .{ .number = float_b - float_a } });
+        },
+        else => unreachable,
+    }
+}
+
+fn multiply(hither: *Hither) Error!void {
+    if (try preamble(hither)) return;
+    const a = hither.pop() orelse return error.BadArgument;
+    const b = hither.pop() orelse return error.BadArgument;
+    const ret_type = try arithmeticCoerce(a.tag, b.tag);
+    switch (ret_type) {
+        .integer => try hither.push(.{
+            .tag = .integer,
+            .data = .{
+                .integer = std.math.mul(i64, a.data.integer, b.data.integer) catch return error.ArithmeticOverflow,
+            },
+        }),
+        .number => {
+            const float_a = toNumber(a) catch unreachable;
+            const float_b = toNumber(b) catch unreachable;
+            try hither.push(.{ .tag = .number, .data = .{ .number = float_a * float_b } });
+        },
+        else => unreachable,
+    }
+}
+
+fn divide(hither: *Hither) Error!void {
+    if (try preamble(hither)) return;
+    const a = hither.pop() orelse return error.BadArgument;
+    const b = hither.pop() orelse return error.BadArgument;
+    const ret_type = try arithmeticCoerce(a.tag, b.tag);
+    switch (ret_type) {
+        .integer => try hither.push(.{
+            .tag = .integer,
+            .data = .{ .integer = std.math.divTrunc(i64, b.data.integer, a.data.integer) catch |err| switch (err) {
+                error.DivisionByZero => return error.ZeroDenominator,
+                error.Overflow => return error.ArithmeticOverflow,
+            } },
+        }),
+        .number => {
+            const float_a = toNumber(a) catch unreachable;
+            const float_b = toNumber(b) catch unreachable;
+            if (float_a == 0) return error.ZeroDenominator;
+            try hither.push(.{ .tag = .number, .data = .{ .number = float_b / float_a } });
+        },
+        else => unreachable,
+    }
+}
+
+fn modulo(hither: *Hither) Error!void {
+    if (try preamble(hither)) return;
+    const a = hither.pop() orelse return error.BadArgument;
+    const b = hither.pop() orelse return error.BadArgument;
+    const ret_type = try arithmeticCoerce(a.tag, b.tag);
+    switch (ret_type) {
+        .integer => {
+            if (a.data.integer == 0) return error.ZeroDenominator;
+            try hither.push(.{ .tag = .integer, .data = .{ .integer = std.math.mod(i64, b.data.integer, a.data.integer) catch return error.BadArgument } });
+        },
+        .number => {
+            const float_a = toNumber(a) catch unreachable;
+            const float_b = toNumber(b) catch unreachable;
+            if (float_a == 0) return error.ZeroDenominator;
+            try hither.push(.{
+                .tag = .number,
+                .data = .{ .number = std.math.mod(f64, float_b, float_a) catch return error.BadArgument },
+            });
+        },
+        else => unreachable,
+    }
+}
+
+const zero: Cell = .{ .tag = .integer, .data = .{ .integer = 0 } };
+const one: Cell = .{ .tag = .integer, .data = .{ .integer = 1 } };
+
+// -- COMPARING --
+
+fn greater(hither: *Hither) Error!void {
+    if (try preamble(hither)) return;
+    const b = hither.pop() orelse return error.BadArgument;
+    const a = hither.pop() orelse return error.BadArgument;
+    const ret_type = try arithmeticCoerce(a.tag, b.tag);
+    try hither.push(switch (ret_type) {
+        .integer => if (a.data.integer > b.data.integer) one else zero,
+        .number => number: {
+            const float_a = toNumber(a) catch unreachable;
+            const float_b = toNumber(b) catch unreachable;
+            if (std.math.approxEqRel(f64, float_a, float_b, 10 * std.math.floatEps(f64))) break :number zero;
+            break :number if (float_a > float_b) one else zero;
+        },
+        else => unreachable,
+    });
+}
+
+fn less(hither: *Hither) Error!void {
+    if (try preamble(hither)) return;
+    const b = hither.pop() orelse return error.BadArgument;
+    const a = hither.pop() orelse return error.BadArgument;
+    const ret_type = try arithmeticCoerce(a.tag, b.tag);
+    try hither.push(switch (ret_type) {
+        .integer => if (a.data.integer < b.data.integer) one else zero,
+        .number => number: {
+            const float_a = toNumber(a) catch unreachable;
+            const float_b = toNumber(b) catch unreachable;
+            if (std.math.approxEqRel(f64, float_a, float_b, 10 * std.math.floatEps(f64))) break :number zero;
+            break :number if (float_a < float_b) one else zero;
+        },
+        else => unreachable,
+    });
+}
+
+fn greaterEq(hither: *Hither) Error!void {
+    if (try preamble(hither)) return;
+    const b = hither.pop() orelse return error.BadArgument;
+    const a = hither.pop() orelse return error.BadArgument;
+    const ret_type = try arithmeticCoerce(a.tag, b.tag);
+    try hither.push(switch (ret_type) {
+        .integer => if (a.data.integer >= b.data.integer) one else zero,
+        .number => number: {
+            const float_a = toNumber(a) catch unreachable;
+            const float_b = toNumber(b) catch unreachable;
+            if (std.math.approxEqRel(f64, float_a, float_b, 10 * std.math.floatEps(f64))) break :number one;
+            break :number if (float_a >= float_b) one else zero;
+        },
+        else => unreachable,
+    });
+}
+
+fn lessEq(hither: *Hither) Error!void {
+    if (try preamble(hither)) return;
+    const b = hither.pop() orelse return error.BadArgument;
+    const a = hither.pop() orelse return error.BadArgument;
+    const ret_type = try arithmeticCoerce(a.tag, b.tag);
+    try hither.push(switch (ret_type) {
+        .integer => if (a.data.integer <= b.data.integer) one else zero,
+        .number => number: {
+            const float_a = toNumber(a) catch unreachable;
+            const float_b = toNumber(b) catch unreachable;
+            if (std.math.approxEqRel(f64, float_a, float_b, 10 * std.math.floatEps(f64))) break :number one;
+            break :number if (float_a <= float_b) one else zero;
+        },
+        else => unreachable,
+    });
+}
+
+fn equal(hither: *Hither) Error!void {
+    if (try preamble(hither)) return;
+    const a = hither.pop() orelse return error.BadArgument;
+    const b = hither.pop() orelse return error.BadArgument;
+    if (a.tag != b.tag) {
+        _ = arithmeticCoerce(a.tag, b.tag) catch {
+            try hither.push(zero);
+            return;
+        };
+        const float_a = toNumber(a) catch unreachable;
+        const float_b = toNumber(b) catch unreachable;
+        try hither.push(if (std.math.approxEqRel(f64, float_a, float_b, 10 * std.math.floatEps(f64))) one else zero);
+        return;
+    }
+    if (a.eqlShallow(b)) {
+        try hither.push(one);
+        return;
+    }
+    if (a.tag != .slice) {
+        try hither.push(zero);
+        return;
+    }
+    if (a.slice_is == .definition or b.slice_is == .definition) {
+        try hither.push(zero);
+        return;
+    }
+    const slice_a = try toBytes(hither, a);
+    const slice_b = try toBytes(hither, b);
+    try hither.push(if (std.mem.eql(u8, slice_a, slice_b)) one else zero);
+}
+
+// -- STACK MANIPULATION --
+
+fn dupe(hither: *Hither) Error!void {
+    if (try preamble(hither)) return;
+    const cell = hither.pop() orelse return error.BadArgument;
+    try hither.push(cell);
+    try hither.push(cell);
+}
+
+fn swap(hither: *Hither) Error!void {
+    if (try preamble(hither)) return;
+    const a = hither.pop() orelse return error.BadArgument;
+    const b = hither.pop() orelse return error.BadArgument;
+    try hither.push(a);
+    try hither.push(b);
+}
+
+fn heightIs(hither: *Hither) Error!void {
+    if (try preamble(hither)) return;
+    const height: i64 = @intCast(hither.stack.len);
+    try hither.push(.{ .tag = .integer, .data = .{ .integer = height } });
+}
+
+fn setTo(hither: *Hither) Error!void {
+    if (try preamble(hither)) return;
+    const cell = hither.pop() orelse return error.BadArgument;
+    if (cell.tag != .integer) return error.BadArgument;
+    const height: usize = if (cell.data.integer < 0) 0 else @intCast(cell.data.integer);
+    while (hither.stack.len < height) {
+        try hither.push(zero);
+    }
+    hither.stack.len = height;
+}
+
+fn drop(hither: *Hither) Error!void {
+    if (try preamble(hither)) return;
+    _ = hither.pop();
+}
+
+// -- LOGIC --
+
+fn andFn(hither: *Hither) Error!void {
+    if (try preamble(hither)) return;
+    const a = hither.pop() orelse return error.BadArgument;
+    const b = hither.pop() orelse return error.BadArgument;
+    try hither.push(if (a.eqlShallow(zero) or b.eqlShallow(zero)) zero else one);
+}
+
+fn orFn(hither: *Hither) Error!void {
+    if (try preamble(hither)) return;
+    const a = hither.pop() orelse return error.BadArgument;
+    const b = hither.pop() orelse return error.BadArgument;
+    try hither.push(if (a.eqlShallow(zero) and b.eqlShallow(zero)) zero else one);
+}
+
+fn notFn(hither: *Hither) Error!void {
+    if (try preamble(hither)) return;
+    const a = hither.pop() orelse return error.BadArgument;
+    try hither.push(if (a.eqlShallow(zero)) one else zero);
+}
+
+// -- misc --
+
+fn print(hither: *Hither) Error!void {
+    if (try preamble(hither)) return;
+    const writer = hither.output orelse return error.NotSupported;
+    hither.printStack(writer) catch return error.IOError;
+}
+
+fn toBytes(hither: *Hither, cell: Cell) Error![]const u8 {
+    if (cell.tag != .slice or cell.slice_is == .definition) return error.BadArgument;
+    const ptr = hither.heap.fromAddress(cell.data.slice.address) orelse return error.BadArgument;
+    return ptr[0..cell.data.slice.length];
+}
+
+fn toCells(hither: *Hither, cell: Cell) Error![]const Cell {
+    if (cell.tag != .slice or cell.slice_is != .definition) return error.BadArgument;
+    const byte_ptr = hither.heap.fromAddress(cell.data.slice.address) orelse return error.BadArgument;
+    const ptr: [*]Cell = @ptrCast(@alignCast(byte_ptr));
+    return ptr[0..cell.data.slice.length];
+}
+
+fn join(hither: *Hither) Error!void {
+    if (try preamble(hither)) return;
+    const a = hither.pop() orelse return error.BadArgument;
+    const b = hither.pop() orelse return error.BadArgument;
+    if (a.slice_is != b.slice_is) return error.BadArgument;
+    if (a.slice_is == .word) return error.BadArgument;
+    if (a.slice_is == .string) {
+        const a_slice = try toBytes(hither, a);
+        const b_slice = try toBytes(hither, b);
+        const c_slice = try std.mem.concat(hither.heap.allocator(), u8, &.{ b_slice, a_slice });
+        const address = hither.heap.addressOf(c_slice.ptr) catch unreachable;
+        try hither.push(.{
+            .tag = .slice,
+            .data = .{ .slice = .{
+                .address = address,
+                .length = @intCast(c_slice.len),
+            } },
+        });
+    } else {
+        const a_slice = try toCells(hither, a);
+        const b_slice = try toCells(hither, b);
+        const c_slice = try std.mem.concat(hither.heap.allocator(), Cell, &.{ b_slice, a_slice });
+        const address = hither.heap.addressOf(c_slice.ptr) catch unreachable;
+        try hither.push(.{
+            .tag = .slice,
+            .slice_is = .definition,
+            .data = .{ .slice = .{
+                .address = address,
+                .length = @intCast(c_slice.len),
+            } },
+        });
+    }
+}
+
+// -- programming language-y things --
+
+fn variable(hither: *Hither) Error!void {
+    if (try preamble(hither)) return;
+    const a = hither.pop() orelse return error.BadArgument;
+    const name = try toBytes(hither, a);
+    if (std.mem.indexOfAny(u8, name, "\r\n\t ") != null) return error.BadArgument;
+    const val = hither.pop() orelse return error.BadArgument;
+    const slice = try hither.heap.allocator().alloc(Cell, 1);
+    slice[0] = val;
+    const addr = hither.heap.addressOf(slice.ptr) catch unreachable;
+    if (hither.dictionary.count() == hither.dictionary.capacity()) return error.OutOfMemory;
+    const res = hither.dictionary.getOrPutAssumeCapacity(name);
+    res.key_ptr.* = name;
+    res.value_ptr.* = .{
+        .tag = .slice,
+        .slice_is = .definition,
+        .data = .{
+            .slice = .{ .address = addr, .length = 1 },
+        },
+    };
+}
+
+fn call(hither: *Hither) Error!void {
+    if (try preamble(hither)) return;
+    const cell = hither.pop() orelse return error.BadArgument;
+    try hither.push(cell);
+}
+
+fn whileFn(hither: *Hither) Error!void {
+    if (try preamble(hither)) return;
+    const cond = hither.pop() orelse return error.BadArgument;
+    const func = hither.pop() orelse return error.BadArgument;
+    while (true) {
+        try hither.push(cond);
+        const cell = hither.pop() orelse return error.BadArgument;
+        if (cell.eqlShallow(zero)) break;
+        try hither.push(func);
+    }
+}
+
+fn noop(hither: *Hither) Error!void {
+    if (try preamble(hither)) return;
+}
+
+/// just leaves itself on top of the return stack, to be popped by isXt
+/// exception: if the return stack satisfies isDeferred, pushes xt onto the stack instead
+fn xt(hither: *Hither) Error!void {
+    const self = hither.ret.pop();
+    hither.ret.appendAssumeCapacity(self);
+    if (try preamble(hither)) return;
+    if (isDeferred(hither)) {
+        if (hither.stack.len == hither.stack.capacity) return error.StackOverflow;
+        hither.stack.appendAssumeCapacity(self);
+    } else hither.ret.appendAssumeCapacity(self);
+}
+
+/// leaves itself on top of the return stack, to be popped by lambdaEnd
+fn lambdaStart(hither: *Hither) Error!void {
+    const this = hither.ret.pop();
+    hither.ret.appendAssumeCapacity(this);
+    if (try preamble(hither)) {
+        hither.ret.appendAssumeCapacity(this);
+        return;
+    }
+    // push the stack location onto the return stack for lambdaEnd to use it
+    const height: Cell = .{
+        .tag = .integer,
+        .data = .{ .integer = @intCast(hither.stack.len) },
+    };
+    hither.ret.appendAssumeCapacity(height);
+    if (hither.ret.len == hither.ret.capacity) return error.StackOverflow;
+    hither.ret.appendAssumeCapacity(this);
+}
+
+/// leaves itself on top of the return stack, to be popped by then
+fn ifStart(hither: *Hither) Error!void {
+    const this = hither.ret.pop();
+    hither.ret.appendAssumeCapacity(this);
+    if (try preamble(hither)) {
+        hither.ret.appendAssumeCapacity(this);
+        return;
+    }
+    // push the stack location onto the return stack for then to use it
+    const height: Cell = .{
+        .tag = .integer,
+        .data = .{ .integer = @intCast(hither.stack.len) },
+    };
+    hither.ret.appendAssumeCapacity(height);
+    if (hither.ret.len == hither.ret.capacity) return error.StackOverflow;
+    hither.ret.appendAssumeCapacity(this);
+}
+
+/// leaves itself on top of the return stack, to be popped by then
+fn elseStart(hither: *Hither) Error!void {
+    const this = hither.ret.pop();
+    defer hither.ret.appendAssumeCapacity(this);
+    const other = hither.ret.popOrNull() orelse return error.PairMismatch;
+    {
+        defer hither.ret.appendAssumeCapacity(other);
+        const if_cell: Cell = .{
+            .tag = .builtin,
+            .data = .{ .builtin = @field(@This(), "ifStart") },
+        };
+        if (!other.eqlShallow(if_cell)) return error.PairMismatch;
+        hither.ret.appendAssumeCapacity(this);
+        if (try preamble(hither)) return;
+    }
+    // push the stack location onto the return stack for then to use it
+    const height: Cell = .{
+        .tag = .integer,
+        .data = .{ .integer = @intCast(hither.stack.len) },
+    };
+    if (hither.ret.len == hither.ret.capacity - 1) return error.StackOverflow;
+    hither.ret.appendAssumeCapacity(height);
+}
+
+fn captureFrom(hither: *Hither, location: usize) Error!Cell {
+    if (location > hither.stack.len) return error.BadArgument;
+    const slice = try hither.heap.allocator().alloc(Cell, hither.stack.len - location);
+    defer hither.stack.len = location;
+    for (slice, location..) |*datum, i| {
+        datum.* = hither.stack.get(i);
+    }
+    const addr = hither.heap.addressOf(slice.ptr) catch return .{
+        .tag = .slice,
+        .slice_is = .definition,
+        .data = .{
+            .slice = .{ .address = 0, .length = 0 },
+        },
+    };
+    return .{
+        .tag = .slice,
+        .slice_is = .definition,
+        .data = .{
+            .slice = .{ .address = addr, .length = @intCast(slice.len) },
+        },
+    };
+}
+
+fn then(hither: *Hither) Error!void {
+    const this = hither.ret.pop();
+    const else_cell: Cell = .{
+        .tag = .builtin,
+        .data = .{ .builtin = @field(@This(), "elseStart") },
+    };
+    const if_cell: Cell = .{
+        .tag = .builtin,
+        .data = .{ .builtin = @field(@This(), "ifStart") },
+    };
+
+    const other = hither.ret.popOrNull() orelse return error.PairMismatch;
+    if (other.eqlShallow(else_cell)) {
+        const loc_or_if = hither.ret.popOrNull() orelse return error.PairMismatch;
+        if (loc_or_if.eqlShallow(if_cell)) {
+            hither.ret.appendAssumeCapacity(this);
+            if (try preamble(hither)) return;
+            return error.PairMismatch;
+        }
+        if (loc_or_if.tag != .integer) return error.PairMismatch;
+
+        const should_be_if = hither.ret.popOrNull() orelse return error.PairMismatch;
+        if (!should_be_if.eqlShallow(if_cell)) return error.PairMismatch;
+        const if_loc = hither.ret.popOrNull() orelse return error.PairMismatch;
+        if (if_loc.tag != .integer) return error.PairMismatch;
+
+        const else_slice = try captureFrom(hither, @intCast(loc_or_if.data.integer));
+        const if_slice = try captureFrom(hither, @intCast(if_loc.data.integer));
+        const cond = hither.pop() orelse return error.BadArgument;
+        if (cond.eqlShallow(zero)) try hither.push(else_slice) else try hither.push(if_slice);
+    } else if (other.eqlShallow(if_cell)) {
+        hither.ret.appendAssumeCapacity(this);
+        if (try preamble(hither)) return;
+        const location = hither.ret.popOrNull() orelse return error.PairMismatch;
+        if (location.tag != .integer) return error.PairMismatch;
+
+        const if_slice = try captureFrom(hither, @intCast(location.data.integer));
+        const cond = hither.pop() orelse return error.BadArgument;
+        if (cond.eqlShallow(zero)) return;
+        try hither.push(if_slice);
+    } else return error.PairMismatch;
+}
+
+fn lambdaEnd(hither: *Hither) Error!void {
+    const this = hither.ret.pop();
+    const other = hither.ret.popOrNull() orelse return error.PairMismatch;
+    const lambda_cell: Cell = .{
+        .tag = .builtin,
+        .data = .{ .builtin = @field(@This(), "lambdaStart") },
+    };
+    if (!other.eqlShallow(lambda_cell)) return error.PairMismatch;
+    hither.ret.appendAssumeCapacity(this);
+    if (try preamble(hither)) return;
+    const lambda_loc = hither.ret.popOrNull() orelse return error.PairMismatch;
+    if (lambda_loc.tag != .integer) return error.PairMismatch;
+    const slice = try captureFrom(hither, @intCast(lambda_loc.data.integer));
+    if (hither.stack.len == hither.stack.capacity) return error.StackOverflow;
+    hither.stack.appendAssumeCapacity(slice);
+}
+
+fn exit(hither: *Hither) Error!void {
+    if (try preamble(hither)) return;
+    var idx = hither.ret.popOrNull() orelse return;
+    if (idx.tag != .integer) return error.BadArgument;
+    idx.data.integer = -1;
+    hither.ret.appendAssumeCapacity(idx);
+}
+
+// significantly more verbose than a simple for loop so that it can be interrupted by `exit`
+pub fn iterateThrough(hither: *Hither) Error!void {
+    const slice = hither.ret.pop();
+    hither.ret.appendAssumeCapacity(slice);
+    if (try preamble(hither)) return;
+    hither.ret.appendAssumeCapacity(slice);
+    defer _ = hither.ret.popOrNull();
+    const cells = try toCells(hither, slice);
+    const pc_loc = hither.ret.len;
+    if (hither.ret.len == hither.ret.capacity) return error.StackOverflow;
+    hither.ret.appendAssumeCapacity(zero);
+    defer _ = hither.ret.popOrNull();
+    var program_counter: u32 = 0;
+    while (program_counter < slice.data.slice.length) {
+        try hither.push(cells[program_counter]);
+        var pc = hither.ret.get(pc_loc);
+        // blk: {
+        // const writer = hither.output orelse break :blk;
+        // hither.dumpState(writer) catch {};
+        // }
+        if (pc.tag != .integer or pc.data.integer < 0) break;
+        pc.data.integer += 1;
+        program_counter = @intCast(pc.data.integer);
+        hither.ret.set(pc_loc, pc);
+    }
+}
+
+pub fn lookUpWord(hither: *Hither) Error!void {
+    const slice = hither.ret.pop();
+    const bytes = try toBytes(hither, slice);
+    const definition = hither.dictionary.get(bytes) orelse {
+        hither.ret.appendAssumeCapacity(slice);
+        if (try preamble(hither)) return;
+        return error.WordNotFound;
+    };
+    if (isXt(hither) or isDeferred(hither)) {
+        if (hither.stack.len == hither.stack.capacity) return error.StackOverflow;
+        switch (definition.tag) {
+            .builtin => try hither.push(definition),
+            .slice => hither.stack.appendAssumeCapacity(slice),
+            else => unreachable,
+        }
+        return;
+    }
+    try hither.push(definition);
+}
+
+fn dumpState(hither: *Hither) Error!void {
+    if (try preamble(hither)) return;
+    hither.dumpState(hither.output orelse return error.NotSupported) catch return error.IOError;
+}
+
+fn inspect(hither: *Hither) Error!void {
+    if (try preamble(hither)) return;
+    const writer = hither.output orelse return error.NotSupported;
+    const slice = hither.stack.popOrNull() orelse return error.BadArgument;
+    const bytes = try toBytes(hither, slice);
+    const defn = hither.dictionary.get(bytes) orelse return error.WordNotFound;
+    inspectInner(hither, writer, bytes, defn) catch return error.IOError;
+}
+
+fn inspectInner(hither: *Hither, writer: std.io.AnyWriter, name: []const u8, defn: Cell) !void {
+    const inner = try toCells(hither, defn);
+    try writer.print("DEFINITION OF: {s}\n", .{name});
+    for (inner) |c| {
+        switch (c.tag) {
+            .slice => {
+                if (c.slice_is != .definition) {
+                    const bytes = try toBytes(hither, c);
+                    try writer.writeAll(bytes);
+                    try writer.writeAll("\n");
+                } else try writer.print("{}\n", .{c});
+            },
+            else => try writer.print("{}\n", .{c}),
+        }
+    }
+}
+
+fn breakFn(hither: *Hither) Error!void {
+    hither.flush();
+}
+
+test "ref" {
+    _ = keys;
+    _ = vals;
+}
+
+const Hither = @import("hither.zig");
+const Cell = Hither.Cell;
+const Error = Hither.Error;
+const std = @import("std");


### PR DESCRIPTION
this PR corrects a misconception i had about the way a forth should work: in order to have the "left to right" concatenative semantics, functions must be called when they are pushed onto the stack.

i also felt wasteful about my use of the dictionary and pad in the previous version of hither. this PR replaces that memory model with a heap of bounded size, equipped with a `mem.Allocator` and implements a "mark and sweep" style garbage collector that runs when hither's state is flushed (i.e. in the provided REPL implementation, after a full line is processed and found to be complete, or on error).

the new dictionary is a hash map of bounded capacity. the keys to the hash map are strings, whose lifetimes are either tied to the initial allocation of hither (where they are copied over from static-lifetime strings in `hither_lib.keys`) or to the lifetime of the heap, where their presence in the hash map prevents them from being garbage-collected. the values in the hash map are single `Cell` objects, which are either of type `builtin` or of type `slice` with `slice_is == .definition`. for the latter type, the pointed-to slice is on the heap, and this indirection allows for proper variable usage semantics.

BREAKING: 
- `,` is removed
- `name` is replaced by `:=`, which performs both allocation and assignment of dictionary keys. `:=` operates both on single-word strings as `1 "x" :=` creating or assigning the value of `1` to the variable `x` or on words which are "escaped" with `'` as in `1 ' x :=`.
- other inconsistencies between the previous collection of builtins and this collection are possible.